### PR TITLE
(fix): 404 page, layout renders 3 child

### DIFF
--- a/src/pages/404.jsx
+++ b/src/pages/404.jsx
@@ -4,11 +4,15 @@ import Layout from "../components/layout"
 import SEO from "../components/seo"
 
 const NotFoundPage = () => (
-  <Layout>
-    <SEO title="404: Not found" />
-    <h1>NOT FOUND</h1>
-    <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
-  </Layout>
+  <>
+    <SEO title="404: Not found" /> {/* move SEO outside of </Layout> so it's not treated as a child prop */}
+    <Layout>
+      <div>  {/* what this div does is it's wrapping the content so </Layout> will only map one child */}
+        <h1>NOT FOUND</h1>
+        <p>You just hit a route that doesn&#39;t exist... the sadness.</p>
+      </div>
+    </Layout>
+  </>
 )
 
 export default NotFoundPage


### PR DESCRIPTION
hello Gwen, @glfmn.

it seems that the 404 page does not render quite well. the **reason** behind this is, the `ListPane` from `Layout` renders child props 3 times; the seo, h1, and p tag. so i made a wrapper (regular div) to wrap the content and it should render only once.